### PR TITLE
feat(antenna-size): Size of circles get smaller on zoom + fixed heading issue

### DIFF
--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -1,6 +1,13 @@
 'use client';
-import React, { useState } from 'react';
-import { MapContainer, TileLayer } from 'react-leaflet';
+import React, { useState, useEffect } from 'react';
+import {
+  MapContainer,
+  TileLayer,
+  LayersControl,
+  LayerGroup,
+  useMap,
+} from 'react-leaflet';
+import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 
 import Antennas from './Antennas';
@@ -8,6 +15,38 @@ import SectorLobes from './SectorLobes';
 import AntennaInfo from './AntennaInfo';
 
 import { AccessPoint } from '../types';
+
+function DynamicCircleRadius() {
+  const map = useMap();
+
+  useEffect(() => {
+    const updateCircleRadius = () => {
+      const zoom = map.getZoom();
+
+      // Calculate a new radius based on the zoom level
+      const newRadius = Math.max(5, 30 - Math.pow(2, zoom - 13));
+
+      // Update the circle radius
+      map.eachLayer((layer) => {
+        if (layer instanceof L.Circle) {
+          layer.setRadius(newRadius);
+        }
+      });
+    };
+
+    // Listen for zoom events and update the circle radius
+    map.on('zoom', updateCircleRadius);
+
+    // Initial update
+    updateCircleRadius();
+
+    return () => {
+      map.off('zoom', updateCircleRadius);
+    };
+  }, [map]);
+
+  return null;
+}
 
 export default function Map() {
   const [toggleInfo, setToggleInfo] = useState(false);
@@ -43,14 +82,25 @@ export default function Map() {
           attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         />
+        <DynamicCircleRadius />
         {/* Call anything you want to add to the map here. */}
-        <SectorLobes />
-        <Antennas
-          currentAntenna={currentAntenna}
-          setCurrentAntenna={setCurrentAntenna}
-          getToggle={toggleInfo}
-          changeToggle={() => setToggleInfo(!toggleInfo)}
-        />
+        <LayersControl position="bottomleft">
+          <LayersControl.Overlay name="Sector Lobes" checked>
+            <LayerGroup>
+              <SectorLobes />
+            </LayerGroup>
+          </LayersControl.Overlay>
+          <LayersControl.Overlay name="Antennas" checked>
+            <LayerGroup>
+              <Antennas
+                currentAntenna={currentAntenna}
+                setCurrentAntenna={setCurrentAntenna}
+                getToggle={toggleInfo}
+                changeToggle={() => setToggleInfo(!toggleInfo)}
+              />
+            </LayerGroup>
+          </LayersControl.Overlay>
+        </LayersControl>
       </MapContainer>
     </>
   );

--- a/app/components/SectorLobe.tsx
+++ b/app/components/SectorLobe.tsx
@@ -10,12 +10,12 @@ export default function SectorLobe({ key, val }: SectorLobeProps) {
   const center: LatLngExpression = [val.lat, val.lon];
   const [radiusInMeters, setRadiusInMeters] = useState(100); // Adjust this as needed
   const [sectorWidth, setSectorWidth] = useState(45);
-  const [heading, setHeading] = useState(90);
+  const [heading, setHeading] = useState(0);
 
   // holds previous values in case they do not want to commit
   const [tempRadius, setTempRadius] = useState(100);
-  const [tempSectorWidth, setTempSectorWidth] = useState(20);
-  const [tempHeading, setTempHeading] = useState(90);
+  const [tempSectorWidth, setTempSectorWidth] = useState(45);
+  const [tempHeading, setTempHeading] = useState(0);
 
   const radiusRange: number[][] = [
     [0, 45],
@@ -54,10 +54,14 @@ export default function SectorLobe({ key, val }: SectorLobeProps) {
     { length: numberOfVertices + 1 },
     (_, index) => {
       const angle: number =
-        (heading - sectorWidth / 2 + (sectorWidth * index) / numberOfVertices) *
+        (90 +
+          heading -
+          sectorWidth / 2 +
+          (sectorWidth * index) / numberOfVertices) *
         (Math.PI / 180);
 
       const lat: number = center[0] + scaleFactor * Math.sin(angle);
+      // const lng: number = center[1] + scaleFactor * Math.cos(angle) * 0.3;
       const lng: number = center[1] + scaleFactor * Math.cos(angle);
 
       return [lat, lng];


### PR DESCRIPTION
Made it so that the antenna circles will get smaller (minimum radius of 5) based on the zoom level. I also fixed the heading not being accurate (90 North -> 0 North). Also commented it out, but in `SectorLobes.tsx` on line 64 I have the testing of changing to longitude to make it more elliptical shaped (`const lng: number = center[1] + scaleFactor * Math.cos(angle) * 0.3;`). The key is adding the `* 0.3` at the end. I did not want to include it as a definitive change just yet though since there could still be a better way. Closes #125 and Closes #137